### PR TITLE
Add global_parameters documentation entry to mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,7 @@ nav:
       - fileio: usage/fileio.md
       - filters: usage/filters.md
       - preprocessing: usage/preprocessing.md
+      - global_parameters: usage/global_parameters.md
   - Contributing: contributing.md
 
 plugins:


### PR DESCRIPTION
This commit adds a new entry for the global_parameters.md file to the usage documentation section of the mkdocs.yml navigation.