### PR TITLE
fix: derive electrode model code from GridInfo Name, not NRow/NColumn

### DIFF
--- a/src/hdsemg_shared/fileio/file_io.py
+++ b/src/hdsemg_shared/fileio/file_io.py
@@ -3,11 +3,15 @@ from dataclasses import dataclass, field
 from typing import Optional
 import numpy as np
 import os, time, json, re, uuid, requests
+import logging
 
 from .matlab_file_io import MatFileIO
 from .otb_plus_file_io import load_otb_file
 from .otb_4_file_io import load_otb4_file
 from .edf_file_io import load_edf_file
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
 
 # -----------------------------------------------------------------------------
 # Grid dataclass
@@ -26,6 +30,8 @@ class Grid:
         electrodes: Total number of active electrodes
         grid_key: Unique identifier key (format: "{ied}mm_{rows}x{cols}" or with "_N" suffix)
         grid_uid: Unique UUID for this grid instance
+        model_code: Raw electrode model code as written in the file (e.g. "HD10MM0408"),
+            preserved even when rows/cols were normalized against the product catalog
         muscle: Optional muscle name where grid is placed (extracted from OTB4 XML <Muscle> tag)
         requested_path_idx: Optional index of "requested path" description entry
         performed_path_idx: Optional index of "performed path" description entry
@@ -38,6 +44,7 @@ class Grid:
     electrodes: int
     grid_key: str
     grid_uid: str = field(default_factory=lambda: str(uuid.uuid4()))
+    model_code: Optional[str] = None
     muscle: Optional[str] = None
     requested_path_idx: Optional[int] = None
     performed_path_idx: Optional[int] = None
@@ -122,7 +129,7 @@ class EMGFile:
             return self._grids
 
         desc = self.description
-        pattern = re.compile(r"HD(\d{2})MM(\d{2})(\d{2})")
+        pattern = re.compile(r"(HD|GR)(\d{2})MM(\d{2})(\d{2})")
         muscle_pattern = re.compile(r"\[MUSCLE:(.*?)\]")
 
         # Instead of dict, use list to allow multiple grids with same specs
@@ -164,7 +171,10 @@ class EMGFile:
             # Check if within tolerance of the last index
             return abs(new_idx - indices[-1]) <= tolerance
 
-        def find_or_create_grid(scale: int, rows: int, cols: int, idx: int, muscle: Optional[str] = None) -> dict:
+        def find_or_create_grid(scale: int, rows: int, cols: int, idx: int,
+                                muscle: Optional[str] = None,
+                                elec: Optional[int] = None,
+                                model_code: Optional[str] = None) -> dict:
             """Find existing grid with matching specs and contiguous indices, or create new one."""
             # Look for existing grid with same specs
             base_key = f"{scale}mm_{rows}x{cols}"
@@ -185,18 +195,6 @@ class EMGFile:
                     return grid_inst
 
             # No contiguous grid found, create new instance
-            # Look up electrode count from cache
-            prod = f"HD{scale:02d}MM{rows:02d}{cols:02d}".upper()
-            # Create transposed pattern
-            prod_transposed = f"HD{scale:02d}MM{cols:02d}{rows:02d}".upper()
-
-            elec = None
-            for g in grid_data:
-                g_prod_upper = g["product"].upper()
-                if g_prod_upper == prod or g_prod_upper == prod_transposed:
-                    elec = g["electrodes"]
-                    break
-
             if elec is None:
                 elec = rows * cols
 
@@ -218,6 +216,7 @@ class EMGFile:
                 "req_idx": None,
                 "perf_idx": None,
                 "grid_key": grid_key,
+                "model_code": model_code,
                 "muscle": None
             }
             grid_instances.append(new_grid)
@@ -227,7 +226,11 @@ class EMGFile:
             txt = entry_text(ent)
             m = pattern.search(txt)
             if m:
-                scale, rows, cols = map(int, m.groups())
+                prefix, scale, rows, cols = m.group(1).upper(), *map(int, m.groups()[1:])
+                model_code = m.group(0).upper()
+                rows, cols, elec = self._normalize_grid_dims(
+                    prefix, scale, rows, cols, grid_data
+                )
 
                 # Extract muscle information if present (do this BEFORE find_or_create_grid)
                 muscle = None
@@ -236,7 +239,8 @@ class EMGFile:
                     muscle = muscle_match.group(1).strip()
 
                 # Pass muscle info to find_or_create_grid for proper differentiation
-                current_grid = find_or_create_grid(scale, rows, cols, idx, muscle)
+                current_grid = find_or_create_grid(scale, rows, cols, idx, muscle,
+                                                   elec=elec, model_code=model_code)
                 current_grid["indices"].append(idx)
 
                 # Store muscle info in grid if not already set
@@ -262,6 +266,7 @@ class EMGFile:
                 ied_mm=gi["ied_mm"],
                 electrodes=gi["electrodes"],
                 grid_key=gi["grid_key"],
+                model_code=gi.get("model_code"),
                 muscle=gi.get("muscle"),
                 requested_path_idx=gi.get("req_idx"),
                 performed_path_idx=gi.get("perf_idx"),
@@ -276,6 +281,43 @@ class EMGFile:
         else:
             file_format = save_path.split('.')[-1].lower()
             raise ValueError(f"Unsupported save format: {file_format!r}")
+
+    @classmethod
+    def _normalize_grid_dims(cls, prefix: str, scale: int, rows: int, cols: int,
+                             grid_data: list[dict]) -> tuple[int, int, Optional[int]]:
+        """
+        Validate the parsed row/column digits against the product catalog.
+
+        OTBiolab sometimes writes the two 2-digit groups in reversed order
+        (e.g. "HD10MM0408" for the matrix that only exists as HD10MM0804).
+        The electrode count is identical either way, so the transposition is
+        invisible downstream. If the parsed order is not a real product but the
+        reversed order is, the reversed order wins and the swap is logged.
+
+        Returns (rows, cols, electrodes) - electrodes is None when the product
+        is unknown (empty/unavailable catalog), leaving rows/cols untouched.
+        """
+        catalog = {g["product"].upper(): g["electrodes"] for g in grid_data if "product" in g}
+        prod = f"{prefix}{scale:02d}MM{rows:02d}{cols:02d}"
+        prod_transposed = f"{prefix}{scale:02d}MM{cols:02d}{rows:02d}"
+
+        if prod in catalog:
+            return rows, cols, catalog[prod]
+
+        if prod_transposed in catalog:
+            logger.warning(
+                "Electrode model %s does not exist in the product catalog; "
+                "%s does. Normalizing grid to %dx%d (rows x cols).",
+                prod, prod_transposed, cols, rows,
+            )
+            return cols, rows, catalog[prod_transposed]
+
+        # Also hit by the pseudo-grids OTB4 emits for control/aux tracks, so debug.
+        logger.debug(
+            "Electrode model %s not found in the product catalog; "
+            "using the row/column order as written in the file.", prod,
+        )
+        return rows, cols, None
 
     @classmethod
     def _load_grid_data(cls) -> list[dict]:

--- a/src/hdsemg_shared/fileio/otb_4_file_io.py
+++ b/src/hdsemg_shared/fileio/otb_4_file_io.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 import shutil
 import tarfile
 import tempfile
@@ -138,6 +139,39 @@ def load_otb4_file(file_path):
         raise ValueError(f"Could not align data ({data.shape}) with time ({time.shape})")
 
     return data, time, description_array, sampling_frequency, file_name, file_size
+
+
+MODEL_CODE_RE = re.compile(r"^(HD|GR)\d{2}MM\d{4}$")
+
+
+def grid_pattern_from_info(grid_info):
+    """
+    Build the electrode model code for a track's GridInfo.
+
+    The <Description><Name> field carries the real OTB product code
+    (e.g. "HD08MM1305"). Prefer it: <NRow>/<NColumn> use the opposite
+    orientation to the digits in the product code (NRow=5, NColumn=13 for
+    HD08MM1305), so synthesizing the code from them yields a product that does
+    not exist ("HD08MM0513") and silently transposes the grid downstream.
+
+    Falls back to the synthesized code only when <Name> is not a model code
+    (custom/renamed grids).
+    """
+    name = str(grid_info.get("Name", "")).strip().upper()
+    if MODEL_CODE_RE.match(name):
+        return name
+
+    ied = grid_info.get("IED", 1)
+    rows = grid_info.get("NRow", 1)
+    cols = grid_info.get("NColumn", 1)
+    fallback = f"HD{ied:02d}MM{rows:02d}{cols:02d}"
+    # Non-grid tracks (Quaternion, Control Signal, Force, ...) land here routinely,
+    # so this is debug rather than a warning.
+    logger.debug(
+        "GridInfo Name %r is not a product code; falling back to %s synthesized "
+        "from NRow/NColumn, which may be transposed.", grid_info.get("Name"), fallback
+    )
+    return fallback
 
 
 def parse_otb4_tracks_xml(xml_file):
@@ -382,7 +416,7 @@ def read_novecento_plus(signals, track_info_list, trapezoidal_tracks, tmpdir):
 
             # Only use grids with IED > 1 or many electrodes (real EMG grids)
             if ied > 1 or electrodes > 4:
-                last_valid_grid_pattern = f"HD{ied:02d}MM{rows:02d}{cols:02d}"
+                last_valid_grid_pattern = grid_pattern_from_info(grid_info)
                 logger.debug(f"Found valid EMG grid pattern: {last_valid_grid_pattern}")
 
     # We'll create a big list of channel blocks
@@ -568,10 +602,7 @@ def read_novecento_plus(signals, track_info_list, trapezoidal_tracks, tmpdir):
 
                 if grid_info:
                     # Valid EMG grid: use its own pattern (no REF marker)
-                    ied = grid_info["IED"]
-                    rows = grid_info["NRow"]
-                    cols = grid_info["NColumn"]
-                    grid_pattern = f"HD{ied:02d}MM{rows:02d}{cols:02d}"
+                    grid_pattern = grid_pattern_from_info(grid_info)
                     desc = f"{grid_id} {grid_pattern} ch{c+1}"
                     # Add muscle information if available
                     if muscle:
@@ -701,7 +732,7 @@ def read_novecento_plus(signals, track_info_list, trapezoidal_tracks, tmpdir):
     # IMPORTANT: We need to detect grid boundaries from the track structure, not just pattern changes
     # Multiple grids can have the same pattern (e.g., 2x HD10MM0804 on different muscles)
     import re
-    grid_pattern_regex = re.compile(r'HD\d{2}MM\d{4}')
+    grid_pattern_regex = re.compile(r'(?:HD|GR)\d{2}MM\d{4}')
 
     # Build grid boundaries directly from track structure
     # We'll track which tracks were processed and create boundaries at track level
@@ -751,7 +782,7 @@ def read_novecento_plus(signals, track_info_list, trapezoidal_tracks, tmpdir):
                 electrodes = rows * cols
                 if ied > 1 or electrodes > 4:
                     is_emg_grid = True
-                    grid_pattern = f"HD{ied:02d}MM{rows:02d}{cols:02d}"
+                    grid_pattern = grid_pattern_from_info(grid_info)
 
             # Only create boundaries for valid EMG grids
             if is_emg_grid and grid_pattern:
@@ -911,11 +942,7 @@ def read_standard_otb4(signals, track_info_list, trapezoidal_tracks, tmpdir):
         for c in range(nchan):
             # If grid info is available, format description to match expected pattern
             if grid_info:
-                # Format: HD{IED}MM{rows:02d}{cols:02d}
-                ied = grid_info["IED"]
-                rows = grid_info["NRow"]
-                cols = grid_info["NColumn"]
-                grid_pattern = f"HD{ied:02d}MM{rows:02d}{cols:02d}"
+                grid_pattern = grid_pattern_from_info(grid_info)
                 desc = f"{dev} {grid_pattern} ch{c+1}"
                 # Add muscle information if available
                 if muscle:

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -1,0 +1,79 @@
+"""Grid dimension normalization against the OTB product catalog (issue #50)."""
+import json
+import numpy as np
+import pytest
+
+import hdsemg_shared.fileio.file_io as FIOmod
+from hdsemg_shared.fileio.file_io import EMGFile
+
+# Real catalog entries: HD10MM0408 does not exist, HD10MM0804 does.
+CATALOG = [
+    {"product": "HD10MM0804", "electrodes": 32},
+    {"product": "GR08MM1305", "electrodes": 64},
+]
+
+
+def _emg(monkeypatch, tmp_path, model_code, catalog=CATALOG):
+    cache = tmp_path / "grid.json"
+    cache.write_text(json.dumps(catalog))
+    monkeypatch.setattr(EMGFile, "CACHE_PATH", str(cache))
+    monkeypatch.setattr(EMGFile, "_grid_cache", None)
+    monkeypatch.setattr(FIOmod.requests, "get", lambda *a, **k: pytest.fail("no HTTP"))
+
+    desc = [f"Novecento+ (141 - 172) {model_code} ch1 [MUSCLE:Vastus Medialis Muscle Right]"]
+    monkeypatch.setattr(
+        FIOmod.MatFileIO, "load",
+        staticmethod(lambda path: (np.zeros((2, 1)), np.arange(2), desc, 2000, "f.mat", 1)),
+    )
+    return EMGFile.load("f.mat").grids[0]
+
+
+def test_reversed_digits_are_normalized_to_the_real_product(monkeypatch, tmp_path):
+    g = _emg(monkeypatch, tmp_path, "HD10MM0408")
+    assert (g.rows, g.cols) == (8, 4)
+    assert g.grid_key == "10mm_8x4"
+    assert g.electrodes == 32
+    assert g.model_code == "HD10MM0408"  # provenance preserved
+
+
+def test_correct_digits_are_left_alone(monkeypatch, tmp_path):
+    g = _emg(monkeypatch, tmp_path, "HD10MM0804")
+    assert (g.rows, g.cols) == (8, 4)
+    assert g.model_code == "HD10MM0804"
+
+
+def test_gr_products_are_recognized(monkeypatch, tmp_path):
+    g = _emg(monkeypatch, tmp_path, "GR08MM1305")
+    assert (g.rows, g.cols, g.ied_mm) == (13, 5, 8)
+    assert g.electrodes == 64
+
+
+def test_unknown_product_keeps_parsed_order(monkeypatch, tmp_path):
+    g = _emg(monkeypatch, tmp_path, "HD99MM0203", catalog=[])
+    assert (g.rows, g.cols) == (2, 3)
+    assert g.electrodes == 6
+
+
+# --- OTB4 model code source (issue #50 root cause) --------------------------
+from hdsemg_shared.fileio.otb_4_file_io import grid_pattern_from_info
+
+
+def test_model_code_comes_from_grid_name_not_nrow_ncolumn():
+    # Real GridInfo from tests/data/*.otb4: NRow/NColumn are in the opposite
+    # orientation to the digits in the product code.
+    gi = {"Name": "HD08MM1305", "NRow": 5, "NColumn": 13, "IED": 8}
+    assert grid_pattern_from_info(gi) == "HD08MM1305"  # not HD08MM0513
+
+
+def test_non_product_names_fall_back_to_synthesized_code():
+    gi = {"Name": "Control Signal", "NRow": 1, "NColumn": 1, "IED": 1}
+    assert grid_pattern_from_info(gi) == "HD01MM0101"
+
+
+def test_otb4_grid_has_catalog_orientation():
+    from hdsemg_shared.fileio.file_io import EMGFile
+    g = EMGFile.load("tests/data/CE13_TibAnt_AM_04062025_Trap3.otb4").grids[0]
+    assert (g.rows, g.cols) == (13, 5)
+    assert g.grid_key == "8mm_13x5"
+    assert g.model_code == "HD08MM1305"
+    assert len(g.emg_indices) == 64


### PR DESCRIPTION
Fixes #50.

## The actual cause

The issue assumed OTBiolab writes reversed model codes. It doesn't — **we generate them.**

OTB4 tracks carry the real product code in `<Description><Name>`, but the loader ignored it and synthesized its own from `<NRow>`/`<NColumn>`. Those fields use the opposite orientation to the digits in the product code. From `tests/data/CE13_TibAnt_AM_04062025_Trap3.otb4`:

```
Name=HD08MM1305   NRow=5   NColumn=13   IED=8
```

`f"HD{ied:02d}MM{rows:02d}{cols:02d}"` → `HD08MM0513`, a product that does not exist. Same mechanism turns an `HD10MM0804` recording into `HD10MM0408`. The electrode count is identical under transposition (64 either way), so every downstream shape check passed and the grid was silently transposed. `Name` was previously used only in debug log lines.

It was at four sites in `otb_4_file_io.py` (old lines 385, 574, 754, 918).

Product-code digit order confirmed against the OTB pinout sheet (`Arrays-Matrices-pinout.pdf`, REV7): `HD<ied>MM<rows><cols>` — `HD20MM1602` = 16×2 = 32 el., `HD10MM0808` = 8×8 = 64, `HD08MM1305` = 13×5 (64 el., one corner absent). No `HD10MM0408` exists.

## Changes

**`otb_4_file_io.py`**
- New `grid_pattern_from_info()`: returns the GridInfo `Name` when it matches `^(HD|GR)\d{2}MM\d{4}$`; falls back to the synthesized code only for non-grid tracks (Quaternion, Control Signal, Force), which is the routine case and logs at debug.
- All four pattern-building sites call it.
- Grid boundary regex accepts `GR*`, not just `HD*`.
- Module-level `import re` (was imported inside a function).

**`file_io.py`**
- New `_normalize_grid_dims()`: validates the parsed digit order against the product catalog before the `Grid` is built. Exact hit wins; if only the reversed order is a real product it wins and logs a warning; unknown products keep the parsed order. This replaces the old lookup, which accepted a product *and* its transpose interchangeably and then discarded which one matched.
- Model regex matches `GR*` products (`GR08MM1305`, `GR10MM0808`, …), which previously produced no grid at all.
- `Grid.model_code` preserves the raw code from the file, so normalization doesn't destroy provenance.

The `file_io` normalization is a backstop for `.mat`/`.otb+` descriptions written by other tools — the `.otb4` path no longer needs it.

## Effect

| fixture | before | after |
|---|---|---|
| `CE13_TibAnt_AM_04062025_Trap3.otb4` | `8mm_5x13` (5×13) | `8mm_13x5` (13×5) |
| `novecento.otb4` | `8mm_5x13` | `8mm_13x5` |
| `PeHaOf20241107163930_Ramp01.otb+` | `10mm_8x8` | unchanged |

## Testing

`tests/test_grid.py` was empty; it now holds 7 tests — catalog normalization (reversed → corrected, correct → untouched, `GR*` recognized, empty catalog → parsed order kept) and the OTB4 code source (`Name` wins over `NRow`/`NColumn`, non-product names fall back, real fixture yields 13×5 with 64 EMG channels).

```
43 passed
```

## For the reviewer

- **Not covered by a real file:** there is no `.otb4` recorded with an `HD10MM0804` matrix in `tests/data`, so the specific `0408` case from the issue is covered by a unit test on `grid_pattern_from_info` plus the shared code path, not by a fixture. If you have such a recording, adding it would close that gap.
- `tests/test_brace_height.py` fails to import on `main` as well (`BraceHeightResult` missing from `hdsemg_shared.motor_unit`) — pre-existing, untouched here, so the run above excludes it.
- **Breaking for consumers that stored `grid_key`:** keys change from `8mm_5x13` to `8mm_13x5` for affected recordings. Anything persisting grid keys across this version will not match.
- **Downstream:** `hdsemg-select`'s `_resolve_name` digit-swapping and the silent swapped-dimension branch in `get_display_grid` (johanneskasser/hdsemg-select#97) should now be no-ops, since correct codes and correct orientation arrive. That repo is unchanged by this PR; the suggested `logger.warning` on the swapped branch is still worth adding there as defense in depth.
