### PR TITLE
feat: declare the signal unit on EMGFile

### DIFF
--- a/docs/usage/fileio.md
+++ b/docs/usage/fileio.md
@@ -46,9 +46,37 @@ emg.description        # list or array of channel‐description strings
 emg.sampling_frequency # float
 emg.file_name          # str
 emg.file_size          # int (bytes)
-emg.file_type          # "mat" | "otb" | "otb4"
+emg.file_type          # "mat" | "otb" | "otb4" | "edf"
 emg.channel_count      # int, number of channels (= data.shape[1])
+emg.unit               # "V" | "mV" | "uV" | "a.u." | None – unit of the EMG channels
 ```
+
+#### Signal Unit
+
+`emg.unit` says what the **EMG grid channels** are measured in, taken from what
+the file declares — never guessed from the magnitude of the data. It is `None`
+when the format declares nothing, which is deliberate: an unknown unit is
+recoverable, a wrong default is not.
+
+Reference and auxiliary channels (force, requested/performed path, AUX) are
+**not** in this unit — they carry their own scales.
+
+| Format | Source of the unit | Typical result |
+|---|---|---|
+| `.otb4` | `<UnitOfMeasurement>` of each EMG grid track | `"mV"` |
+| `.otb+` / `.otb` | Fixed by the loader's scaling (ADC counts → volts × 1000) | `"mV"` |
+| `.mat` | Optional `Unit` variable, written by `EMGFile.save` | `None` for plain MATLAB exports |
+| `.edf` | Physical dimension in the EDF header | `"uV"`, or `None` when blank |
+
+When the EMG tracks/signals of one file disagree on a unit, `unit` is `None`
+and a warning is logged.
+
+```python
+emg.scale_to("uV")     # factor, e.g. 1000.0; raises ValueError when unit is None
+uv = emg.to_unit("uV") # a converted copy – EMG channels only, refs untouched
+```
+
+`to_unit` never modifies the original. `"a.u."` is never convertible.
 
 #### Grid Metadata
 
@@ -106,11 +134,17 @@ from hdsemg_shared.fileio.matlab_file_io import MatFileIO
 ```
 
 * **`MatFileIO.load(file_path: str) -> tuple`**
-  Loads a `.mat` and returns exactly
-  `(data, time, description, sampling_frequency, file_name, file_size)`.
+  Loads a `.mat` and returns
+  `(data, time, description, sampling_frequency, file_name, file_size, unit)`.
 
-* **`MatFileIO.save(save_path: str, data, time, description, sampling_frequency)`**
-  Saves the provided arrays/metadata to a `.mat` file.
+* **`MatFileIO.save(save_path: str, data, time, description, sampling_frequency, unit=None)`**
+  Saves the provided arrays/metadata to a `.mat` file. `unit` is written only
+  when it is not `None`, so a round-trip preserves it without inventing one.
+
+!!! note "Loader return tuple"
+    All four loaders now return the declared unit as a seventh element.
+    `EMGFile.load` also accepts the older six-element form, in which case
+    `emg.unit` is `None`.
 
 ---
 

--- a/src/hdsemg_shared/fileio/edf_file_io.py
+++ b/src/hdsemg_shared/fileio/edf_file_io.py
@@ -8,6 +8,8 @@ from typing import Optional
 
 import numpy as np
 
+from .units import normalize_unit
+
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
@@ -33,6 +35,9 @@ def load_edf_file(edf_path: str):
     sampling_frequency : float
     file_name : str
     file_size : int – bytes
+    unit : str | None – physical dimension declared in the EDF header, shared
+        by all data signals; None when the header leaves it blank or the
+        signals disagree.
     """
     edf_path = Path(edf_path)
     file_name = edf_path.name
@@ -60,11 +65,37 @@ def load_edf_file(edf_path: str):
     n_data_channels = header["n_signals"] - len(annotation_indices)
     description = _build_descriptions(n_data_channels, sidecar, channels_tsv_path)
 
+    unit = _header_unit(header, annotation_indices)
+
     logger.info(
-        "EDF loaded: %s | channels=%d | samples=%d | sf=%.1f Hz",
-        file_name, data.shape[0], data.shape[1], sf,
+        "EDF loaded: %s | channels=%d | samples=%d | sf=%.1f Hz | unit=%s",
+        file_name, data.shape[0], data.shape[1], sf, unit,
     )
-    return data, time, description, sf, file_name, file_size
+    return data, time, description, sf, file_name, file_size, unit
+
+
+def _header_unit(header: dict, annotation_indices: set) -> Optional[str]:
+    """
+    Physical dimension shared by every non-annotation signal.
+
+    EDF declares it per signal; returns None when it is blank (common in
+    synthetic exports) or when the signals disagree, since no single unit
+    then describes the data.
+    """
+    units = {
+        normalize_unit(dim)
+        for i, dim in enumerate(header["phys_dims"])
+        if i not in annotation_indices
+    }
+    units.discard(None)
+    if len(units) == 1:
+        return units.pop()
+    if units:
+        logger.warning(
+            "EDF signals declare conflicting units %s; reporting None.",
+            sorted(units),
+        )
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -141,6 +172,7 @@ def _parse_edf_header(raw: bytes) -> dict:
         "phys_maxs":       phys_maxs,
         "dig_mins":        dig_mins,
         "dig_maxs":        dig_maxs,
+        "phys_dims":       phys_dims,
         "sf":              sf,
     }
 

--- a/src/hdsemg_shared/fileio/file_io.py
+++ b/src/hdsemg_shared/fileio/file_io.py
@@ -9,6 +9,7 @@ from .matlab_file_io import MatFileIO
 from .otb_plus_file_io import load_otb_file
 from .otb_4_file_io import load_otb4_file
 from .edf_file_io import load_edf_file
+from .units import conversion_factor, normalize_unit
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
@@ -62,7 +63,8 @@ class EMGFile:
     )
     _grid_cache: list[dict] | None = None
 
-    def __init__(self, data, time, description, sf, file_name, file_size, file_type):
+    def __init__(self, data, time, description, sf, file_name, file_size, file_type,
+                 unit: Optional[str] = None):
         self.data = data
         self.time = time
         self.description = description
@@ -70,6 +72,10 @@ class EMGFile:
         self.file_name = file_name
         self.file_size = file_size
         self.file_type = file_type
+        #: Unit of the EMG channels, one of :data:`~hdsemg_shared.fileio.units.CANONICAL_UNITS`,
+        #: or ``None`` when the file does not declare one. Reference/auxiliary
+        #: channels (force, paths, AUX) are NOT in this unit — see :meth:`to_unit`.
+        self.unit = normalize_unit(unit)
         self.channel_count = data.shape[1] if data.ndim > 1 else 1
 
         # parse out grids *once* on demand
@@ -94,13 +100,16 @@ class EMGFile:
         else:
             raise ValueError(f"Unsupported file type: {suffix!r}")
 
-        data, time, desc, sf, fn, fs = raw
+        # Loaders append the declared unit; tolerate the older 6-tuple so a
+        # third-party loader or a monkeypatched one keeps working.
+        data, time, desc, sf, fn, fs, *extra = raw
+        unit = extra[0] if extra else None
 
         if data.dtype == np.int16:
             data = data.astype(np.float32)
 
         data, time = cls._sanitize(data, time)
-        return cls(data, time, desc, sf, fn, fs, file_type)
+        return cls(data, time, desc, sf, fn, fs, file_type, unit)
 
     @staticmethod
     def _sanitize(data: np.ndarray, time: np.ndarray):
@@ -277,7 +286,8 @@ class EMGFile:
 
     def save(self, save_path: str) -> None:
         if save_path.endswith(".mat"):
-            MatFileIO.save(save_path, self.data, self.time, self.description, self.sampling_frequency)
+            MatFileIO.save(save_path, self.data, self.time, self.description,
+                           self.sampling_frequency, self.unit)
         else:
             file_format = save_path.split('.')[-1].lower()
             raise ValueError(f"Unsupported save format: {file_format!r}")
@@ -407,6 +417,45 @@ class EMGFile:
             Lower-case extensions including the leading dot.
         """
         return [".mat", ".otb", ".otb+", ".otb4", ".edf"]
+
+    def scale_to(self, unit: str) -> float:
+        """
+        Factor that converts this file's EMG channels into ``unit``.
+
+        Raises ``ValueError`` when :attr:`unit` is ``None`` (the file declared
+        nothing) or when either unit is not convertible, e.g. ``"a.u."``.
+
+        Example::
+
+            emg.data[:, grid.emg_indices] * emg.scale_to("uV")
+        """
+        return conversion_factor(self.unit, unit)
+
+    def to_unit(self, unit: str) -> "EMGFile":
+        """
+        Return a copy whose EMG channels are expressed in ``unit``.
+
+        Only the grid EMG channels are scaled. Reference and auxiliary channels
+        (force, requested/performed path, AUX) carry their own units and are
+        left untouched. When no grids could be parsed, every channel is scaled,
+        since there is nothing to distinguish EMG from the rest.
+        """
+        factor = self.scale_to(unit)
+        data = self.data.astype(np.float64)          # always a fresh array
+        emg_indices = sorted({i for g in self.grids for i in g.emg_indices})
+        if emg_indices:
+            data[:, emg_indices] *= factor
+        else:
+            logger.warning(
+                "No grids parsed for %s; scaling every channel to %s.",
+                self.file_name, unit,
+            )
+            data *= factor
+
+        out = self.copy()
+        out.data = data
+        out.unit = unit
+        return out
 
     def copy(self):
         """

--- a/src/hdsemg_shared/fileio/matlab_file_io.py
+++ b/src/hdsemg_shared/fileio/matlab_file_io.py
@@ -5,6 +5,8 @@ import logging
 from pathlib import Path
 import scipy.io as sio
 
+from .units import normalize_unit
+
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
@@ -12,7 +14,11 @@ class MatFileIO:
     @staticmethod
     def load(file_path: str):
         """
-        Returns exactly the same tuple as your old load_mat_file.
+        Returns (data, time, description, sampling_frequency, file_name,
+        file_size, unit).
+
+        ``unit`` comes from the optional ``Unit`` variable (written by
+        :meth:`save`); plain MATLAB exports carry no unit, so it is ``None``.
         """
         mat_data = sio.loadmat(file_path)
         data = mat_data['Data']
@@ -24,12 +30,14 @@ class MatFileIO:
         )
         file_name = Path(file_path).name
         file_size = os.path.getsize(file_path)
-        return data, time, description, sampling_frequency, file_name, file_size
+        unit = normalize_unit(_scalar_text(mat_data.get('Unit')))
+        return data, time, description, sampling_frequency, file_name, file_size, unit
 
     @staticmethod
-    def save(save_file_path, data, time, description, sampling_frequency):
+    def save(save_file_path, data, time, description, sampling_frequency, unit=None):
         """
-        Exactly your save logic.
+        Write a .mat file. ``unit`` is stored only when known, so that a
+        round-trip preserves it without inventing one.
         """
         path_obj = Path(save_file_path)
         if path_obj.suffix.lower() != ".mat":
@@ -42,7 +50,20 @@ class MatFileIO:
             "Description": description,
             "SamplingFrequency": sampling_frequency
         }
+        if unit is not None:
+            mat_dict["Unit"] = unit
         sio.savemat(final_path, mat_dict)
         logger.info(f"MAT file saved successfully: {final_path}")
         return final_path
 
+
+
+def _scalar_text(value):
+    """Unwrap the nested arrays scipy returns for a scalar string variable."""
+    if value is None:
+        return None
+    while hasattr(value, "size"):
+        if value.size != 1:
+            return None
+        value = value.item() if value.ndim == 0 else value.flat[0]
+    return value

--- a/src/hdsemg_shared/fileio/otb_4_file_io.py
+++ b/src/hdsemg_shared/fileio/otb_4_file_io.py
@@ -6,8 +6,11 @@ import tarfile
 import tempfile
 import zipfile
 from pathlib import Path
+from typing import Optional
 
 import numpy as np
+
+from .units import normalize_unit
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
@@ -35,6 +38,9 @@ def load_otb4_file(file_path):
             - sampling_frequency (float): Sampling frequency of the signals.
             - file_name (str): Name of the OTB4 file.
             - file_size (int): Size of the OTB4 file in bytes.
+            - unit (str | None): Unit of the EMG grid channels, as declared by
+              the tracks' <UnitOfMeasurement>. None when the grid tracks
+              disagree or declare nothing recognizable.
 
     Raises:
         ValueError: If the OTB4 file format is unrecognized or if no track info is found.
@@ -108,6 +114,9 @@ def load_otb4_file(file_path):
         gi = tr["GridInfo"]
         logger.debug(f"  {tr['Device']} - {tr['SubTitle']}: {gi['Name']} ({gi['NRow']}x{gi['NColumn']}, IED={gi['IED']}mm)")
 
+    unit = emg_unit_from_tracks(track_info_list)
+    logger.debug(f"OTB4 EMG unit: {unit}")
+
     if device == "Novecento+":
         logger.debug("Using Novecento+ reader")
         data, descriptions, fs_main = read_novecento_plus(signals, track_info_list, trapezoidal_tracks, tmpdir)
@@ -138,10 +147,51 @@ def load_otb4_file(file_path):
     else:
         raise ValueError(f"Could not align data ({data.shape}) with time ({time.shape})")
 
-    return data, time, description_array, sampling_frequency, file_name, file_size
+    return data, time, description_array, sampling_frequency, file_name, file_size, unit
 
 
 MODEL_CODE_RE = re.compile(r"^(HD|GR)\d{2}MM\d{4}$")
+
+
+def is_emg_grid_track(track: dict) -> bool:
+    """
+    True for tracks carrying real EMG grid channels.
+
+    Mirrors the filter the readers apply: control tracks and the pseudo-grids
+    OTB4 emits for IMU/quaternion/aux data (IED=1 with at most 4 electrodes)
+    are not EMG.
+    """
+    if track.get("IsControl", False):
+        return False
+    grid_info = track.get("GridInfo")
+    if not grid_info:
+        return False
+    electrodes = grid_info.get("NRow", 1) * grid_info.get("NColumn", 1)
+    return grid_info.get("IED", 1) > 1 or electrodes > 4
+
+
+def emg_unit_from_tracks(track_info_list: list) -> Optional[str]:
+    """
+    Unit shared by every EMG grid track, or None when they disagree.
+
+    Scoped to the EMG grids on purpose: AUX, force and control tracks in the
+    same file declare their own units (V, A.U.), so no single unit describes
+    every column of the returned data.
+    """
+    units = {
+        normalize_unit(tr.get("UnitOfMeasurement"))
+        for tr in track_info_list
+        if is_emg_grid_track(tr)
+    }
+    units.discard(None)
+    if len(units) == 1:
+        return units.pop()
+    if units:
+        logger.warning(
+            "OTB4 EMG grid tracks declare conflicting units %s; reporting None.",
+            sorted(units),
+        )
+    return None
 
 
 def grid_pattern_from_info(grid_info):
@@ -222,6 +272,7 @@ def parse_otb4_tracks_xml(xml_file):
         is_control_str = _get_text_save(tr_el, "IsControl", default="false", do_strip= True)
         chan_offset_str = _get_text_save(tr_el, "ChannelOffsetInSubPacket", default="0", do_strip= False)
         muscle_str = _get_text_save(tr_el, "Muscle", default="", do_strip= True)
+        unit_str = _get_text_save(tr_el, "UnitOfMeasurement", default="", do_strip=True)
 
         # Konvertierungen
         gain_val = float(gain_str)
@@ -274,6 +325,7 @@ def parse_otb4_tracks_xml(xml_file):
             "SignalStreamPath": path_str,
             "NumberOfChannels": nchan_val,
             "AcquisitionChannel": acq_val,
+            "UnitOfMeasurement": unit_str,  # e.g. "mV", "V", "A.U."
             "SubTitle": subtitle_str,  # Grid identifier
             "GridInfo": grid_info,     # Grid metadata
             "IsControl": is_control_val,  # Whether this is a control/reference signal

--- a/src/hdsemg_shared/fileio/otb_plus_file_io.py
+++ b/src/hdsemg_shared/fileio/otb_plus_file_io.py
@@ -15,7 +15,11 @@ logger.addHandler(logging.NullHandler())
 def load_otb_file(file_path):
     """
     Loads data from a single .otb (or .otb+ / .zip / .tar) archive and returns
-    (data, time, description, sampling_frequency, file_name, file_size).
+    (data, time, description, sampling_frequency, file_name, file_size, unit).
+
+    ``unit`` is always ``"mV"``: the .otb+ abstract declares no unit per
+    channel, but :func:`scale_otb_data` converts the raw ADC counts to volts
+    and multiplies by 1000, so the EMG channels are millivolts by construction.
     """
     logger.debug(f"load_otb_file called with file_path={file_path}")
     file_path_obj = Path(file_path)
@@ -90,7 +94,7 @@ def load_otb_file(file_path):
     shutil.rmtree(tmpdir, ignore_errors=True)
     logger.info(f"OTB file loaded successfully: {file_name}")
 
-    return data_scaled, time, description, sampling_frequency, file_name, file_size
+    return data_scaled, time, description, sampling_frequency, file_name, file_size, "mV"
 
 
 import xml.etree.ElementTree as ET

--- a/src/hdsemg_shared/fileio/units.py
+++ b/src/hdsemg_shared/fileio/units.py
@@ -1,0 +1,66 @@
+"""
+Canonical signal units for :class:`~hdsemg_shared.fileio.file_io.EMGFile`.
+
+Loaders report what the file *declares*, normalized to one of
+``"V"``, ``"mV"``, ``"uV"`` or ``"a.u."``. ``None`` means the format did not
+say — that is deliberate: a consumer can decide what to do about an unknown
+unit, but cannot recover from a default that looks authoritative.
+"""
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
+
+#: The units a loader may report. Anything else normalizes to ``None``.
+CANONICAL_UNITS = ("V", "mV", "uV", "a.u.")
+
+# Scale of one unit expressed in volts. "a.u." is deliberately absent:
+# arbitrary units cannot be converted.
+_VOLT_SCALE = {"V": 1.0, "mV": 1e-3, "uV": 1e-6}
+
+_ALIASES = {
+    "v": "V", "volt": "V", "volts": "V",
+    "mv": "mV", "millivolt": "mV", "millivolts": "mV",
+    # µ (U+00B5 micro sign) and μ (U+03BC greek mu) both occur in OTB files.
+    "uv": "uV", "µv": "uV", "μv": "uV",
+    "microvolt": "uV", "microvolts": "uV",
+    "a.u.": "a.u.", "au": "a.u.", "a.u": "a.u.",
+    "arbitrary": "a.u.", "arbitrary units": "a.u.",
+}
+
+
+def normalize_unit(raw) -> Optional[str]:
+    """
+    Map a unit string as written in a file onto :data:`CANONICAL_UNITS`.
+
+    Returns ``None`` for empty, missing or unrecognized values.
+    """
+    if raw is None:
+        return None
+    text = str(raw).strip()
+    if not text:
+        return None
+    canonical = _ALIASES.get(text.lower())
+    if canonical is None:
+        logger.debug("Unrecognized signal unit %r; reporting None.", text)
+    return canonical
+
+
+def conversion_factor(from_unit: Optional[str], to_unit: str) -> float:
+    """
+    Factor to multiply data in ``from_unit`` by to obtain ``to_unit``.
+
+    Raises ``ValueError`` when either side is unknown or not convertible
+    (``"a.u."`` never is).
+    """
+    if from_unit is None:
+        raise ValueError(
+            "Source unit is unknown (None); the file did not declare one."
+        )
+    if from_unit not in _VOLT_SCALE or to_unit not in _VOLT_SCALE:
+        raise ValueError(
+            f"Cannot convert {from_unit!r} to {to_unit!r}; "
+            f"convertible units are {sorted(_VOLT_SCALE)}."
+        )
+    return _VOLT_SCALE[from_unit] / _VOLT_SCALE[to_unit]

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,0 +1,160 @@
+"""Signal-unit declaration on EMGFile (issue #53)."""
+import numpy as np
+import pytest
+
+import hdsemg_shared.fileio.file_io as FIOmod
+from hdsemg_shared.fileio.file_io import EMGFile
+from hdsemg_shared.fileio.edf_file_io import _header_unit
+from hdsemg_shared.fileio.otb_4_file_io import emg_unit_from_tracks
+from hdsemg_shared.fileio.units import conversion_factor, normalize_unit
+
+
+# ---------------------------------------------------------------- normalize
+@pytest.mark.parametrize("raw,expected", [
+    ("mV", "mV"), ("MV", "mV"), (" millivolt ", "mV"),
+    ("uV", "uV"), ("µV", "uV"), ("μV", "uV"), ("microvolts", "uV"),
+    ("V", "V"), ("volt", "V"),
+    ("A.U.", "a.u."), ("a.u.", "a.u."), ("au", "a.u."),
+    ("", None), (None, None), ("newton", None), ("kV", None),
+])
+def test_normalize_unit(raw, expected):
+    assert normalize_unit(raw) == expected
+
+
+# ---------------------------------------------------------------- conversion
+def test_conversion_factor():
+    assert conversion_factor("mV", "uV") == pytest.approx(1000.0)
+    assert conversion_factor("uV", "mV") == pytest.approx(1e-3)
+    assert conversion_factor("V", "uV") == pytest.approx(1e6)
+    assert conversion_factor("mV", "mV") == pytest.approx(1.0)
+
+
+def test_conversion_factor_rejects_unknown_and_arbitrary():
+    with pytest.raises(ValueError, match="unknown"):
+        conversion_factor(None, "uV")
+    with pytest.raises(ValueError, match="Cannot convert"):
+        conversion_factor("a.u.", "uV")
+    with pytest.raises(ValueError, match="Cannot convert"):
+        conversion_factor("mV", "a.u.")
+
+
+# ---------------------------------------------------------------- otb4 tracks
+def _track(unit, *, rows=13, cols=5, ied=8, control=False):
+    return {
+        "UnitOfMeasurement": unit,
+        "IsControl": control,
+        "GridInfo": {"Name": "HD08MM1305", "NRow": rows, "NColumn": cols, "IED": ied},
+    }
+
+
+def test_otb4_unit_ignores_control_and_pseudo_grids():
+    tracks = [
+        _track("mV"),
+        _track("A.U.", control=True),                    # control signal
+        _track("A.U.", rows=1, cols=4, ied=1),           # quaternion pseudo-grid
+        {"UnitOfMeasurement": "V", "IsControl": False, "GridInfo": None},  # AUX
+    ]
+    assert emg_unit_from_tracks(tracks) == "mV"
+
+
+def test_otb4_unit_none_when_grid_tracks_disagree():
+    assert emg_unit_from_tracks([_track("mV"), _track("uV")]) is None
+
+
+def test_otb4_unit_none_when_nothing_declared():
+    assert emg_unit_from_tracks([_track("")]) is None
+
+
+# ---------------------------------------------------------------- EMGFile
+def _fake_load(unit):
+    """A 2-channel EMG grid plus one reference channel, in `unit`."""
+    def loader(path):
+        data = np.array([[1.0, 2.0, 100.0],
+                         [3.0, 4.0, 200.0],
+                         [5.0, 6.0, 300.0],
+                         [7.0, 8.0, 400.0]])
+        time_arr = np.arange(4.0)
+        desc = ["HD10MM0203 ch1", "HD10MM0203 ch2", "performed path"]
+        return data, time_arr, desc, 1000, "f.mat", 42, unit
+    return loader
+
+
+@pytest.fixture(autouse=True)
+def _no_catalog_fetch(monkeypatch):
+    monkeypatch.setattr(EMGFile, "_grid_cache", [])
+
+
+def test_unit_from_loader(monkeypatch):
+    monkeypatch.setattr(FIOmod.MatFileIO, "load", _fake_load("mV"))
+    assert EMGFile.load("f.mat").unit == "mV"
+
+
+def test_unit_is_none_when_loader_declares_nothing(monkeypatch):
+    monkeypatch.setattr(FIOmod.MatFileIO, "load", _fake_load(None))
+    emg = EMGFile.load("f.mat")
+    assert emg.unit is None
+    with pytest.raises(ValueError):
+        emg.scale_to("uV")
+
+
+def test_load_tolerates_legacy_six_tuple_loader(monkeypatch):
+    six = lambda p: _fake_load("mV")(p)[:6]
+    monkeypatch.setattr(FIOmod.MatFileIO, "load", six)
+    assert EMGFile.load("f.mat").unit is None
+
+
+def test_to_unit_scales_emg_only_and_leaves_original(monkeypatch):
+    monkeypatch.setattr(FIOmod.MatFileIO, "load", _fake_load("mV"))
+    emg = EMGFile.load("f.mat")
+    grid = emg.grids[0]
+    assert grid.emg_indices == [0, 1] and grid.ref_indices == [2]
+
+    converted = emg.to_unit("uV")
+
+    assert converted.unit == "uV"
+    np.testing.assert_allclose(converted.data[:, grid.emg_indices],
+                               emg.data[:, grid.emg_indices] * 1000)
+    # the reference channel keeps its own (unknown) unit
+    np.testing.assert_allclose(converted.data[:, grid.ref_indices],
+                               emg.data[:, grid.ref_indices])
+    # source is untouched
+    assert emg.unit == "mV"
+    np.testing.assert_allclose(emg.data[0], [1.0, 2.0, 100.0])
+
+
+def test_mat_round_trip_preserves_unit(tmp_path, monkeypatch):
+    monkeypatch.setattr(FIOmod.MatFileIO, "load", _fake_load("mV"))
+    emg = EMGFile.load("f.mat")
+    monkeypatch.undo()
+
+    out = tmp_path / "out.mat"
+    emg.save(str(out))
+    assert EMGFile.load(str(out)).unit == "mV"
+
+
+def test_mat_without_unit_stays_none(tmp_path, monkeypatch):
+    monkeypatch.setattr(FIOmod.MatFileIO, "load", _fake_load(None))
+    emg = EMGFile.load("f.mat")
+    monkeypatch.undo()
+
+    out = tmp_path / "out.mat"
+    emg.save(str(out))
+    assert EMGFile.load(str(out)).unit is None
+
+
+# ---------------------------------------------------------------- edf header
+def _edf_header(dims):
+    return {"phys_dims": dims}
+
+
+def test_edf_unit_from_physical_dimension():
+    assert _header_unit(_edf_header(["uV", "uV", "uV"]), set()) == "uV"
+
+
+def test_edf_unit_ignores_annotation_signals():
+    assert _header_unit(_edf_header(["uV", ""]), {1}) == "uV"
+
+
+def test_edf_unit_none_when_blank_or_conflicting():
+    assert _header_unit(_edf_header(["", ""]), set()) is None
+    assert _header_unit(_edf_header(["uV", "mV"]), set()) is None


### PR DESCRIPTION
Closes #53.

## What

`EMGFile` now carries a `unit` attribute saying what the **EMG grid channels** are measured in, taken from what each file declares — never inferred from the magnitude of the data.

```python
emg = EMGFile.load("2_Trap2.otb4")
emg.unit               # "mV"
emg.scale_to("uV")     # 1000.0
uv = emg.to_unit("uV") # converted copy; reference channels untouched
```

`None` when the format declares nothing. That is deliberate: an unknown unit is recoverable, a wrong default is not.

## Per loader

| Loader | Source | Result on the test files |
|---|---|---|
| `otb_4_file_io` | `<UnitOfMeasurement>` of the EMG grid tracks | `2_Trap2.otb4` → `"mV"` |
| `otb_plus_file_io` | Fixed by the loader's own scaling (ADC counts → volts × 1000) | `K_J_CE…MVC3_VM_VL.otb+` → `"mV"` |
| `matlab_file_io` | Optional `Unit` variable, written by `EMGFile.save` | `1_…MVC_PRE_Trial3.mat` → `None` |
| `edf_file_io` | Physical dimension in the EDF header | `sub-sim00_…_emg.edf` → `None` (header field is blank) |

The OTB4 unit is read only from real EMG grid tracks — control tracks and the IMU/quaternion pseudo-grids declare `A.U.`, and the AUX tracks declare `V`. When the EMG tracks of one file disagree, `unit` is `None` and a warning is logged.

## Reference channels

The unit does **not** apply to every column of `data`. Force, requested/performed path and AUX channels carry their own scales — on the `.otb4` above the performed path runs to ~30000 while the EMG sits below 1.1 mV. `to_unit()` therefore scales only the channels belonging to a grid's `emg_indices` and leaves the rest alone.

## Backwards compatibility

- Adding an attribute is additive; consumers that ignore it behave exactly as now.
- Loaders return the unit as a **seventh** tuple element. `EMGFile.load` also accepts the older six-element form (`unit` is then `None`), so a third-party or monkeypatched loader keeps working.
- `MatFileIO.save` gained an optional `unit=None` argument and writes the `Unit` key only when it is not `None`, so files without a declared unit round-trip unchanged.

## Test plan

- [x] `tests/test_units.py` — normalization (incl. both `µ` U+00B5 and `μ` U+03BC), conversion factors, `a.u.` and `None` rejection, OTB4 track selection, EDF header dimension, `to_unit` scoping and immutability, `.mat` round-trip, legacy six-tuple loader.
- [x] Existing suite: 255 passed, 13 skipped.
- [x] Verified against all four real recordings (`.otb4`, `.mat`, `.otb+`, `.edf`) — units as tabled above, EMG absmax 1.0792 mV → 1079.18 µV, reference channels bit-identical after conversion, source object unchanged.

## Notes

`.otb+` reports a constant `"mV"` rather than reading a declared field: the abstract XML carries no per-channel unit, so the honest source is the loader's own scaling. That it is millivolts is confirmed by the data — full scale for that recording is ±16 mV (4.8 V / 2 / gain 150) and the saturated channels read exactly `16.0`.