### PR TITLE
docs: carry the declared signal unit through the usage pages

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,7 @@ This module provides shared logic for HD-sEMG signal processing and file handlin
 - Unified file I/O for HD-sEMG data (including OTB, OTB+, OTB4, MATLAB, and more)
 - **Novecento+** device support with multi-track recordings and control signals
 - Automatic grid metadata extraction from XML files
+- Declared signal unit (`EMGFile.unit`) so amplitudes are never guessed from magnitude
 - Preprocessing utilities for EMG signals
 - Filtering and grid utilities
 - Designed for extensibility and integration in larger EMG analysis pipelines

--- a/docs/usage/fileio.md
+++ b/docs/usage/fileio.md
@@ -2,10 +2,11 @@
 
 The **`hdsemg_shared.fileio`** module provides a interface to:
 
-* Load HD-sEMG data from MATLAB (`.mat`), OTB+ (`.otb+`, `.otb`) or OTB4 (`.otb4`) files
+* Load HD-sEMG data from MATLAB (`.mat`), OTB+ (`.otb+`, `.otb`), OTB4 (`.otb4`) or EDF (`.edf`) files
 * Support for **Novecento+** device files with multi-track recordings and control signals
 * Automatically sanitize and reshape the data/time arrays
 * Extract electrode‐grid metadata (rows, columns, IED, reference channels, etc.)
+* Report the signal unit each file declares, instead of leaving consumers to guess
 * Cache remote grid‐configuration JSON for one week
 * Save back to `.mat` if needed
 
@@ -24,6 +25,7 @@ A single class that bundles:
 * Raw data & time vectors
 * Channel descriptions
 * Sampling frequency, file name, file size, file type
+* The declared signal unit via `.unit`
 * Electrode‐grid metadata via the `.grids` property
 
 #### Loading
@@ -35,7 +37,8 @@ emg = EMGFile.load("session1.mat")
 * **`load(filepath: str) -> EMGFile`**
   Detects the extension and dispatches to the appropriate loader
   (`.mat` → `MatFileIO.load`, `.otb+`/`.otb` → `otb_plus_file_io`,
-  `.otb4` → `otb_4_file_io`), then sanitizes and returns an `EMGFile`.
+  `.otb4` → `otb_4_file_io`, `.edf` → `edf_file_io`), then sanitizes and
+  returns an `EMGFile`.
 
 #### Attributes
 
@@ -229,7 +232,12 @@ Novecento+ files may contain:
   * OTB4 (`.otb4`) → `otb_4_file_io.load_otb4_file`
     * **Novecento+** device detection and multi-track loading
     * Grid metadata extraction from XML
+  * EDF / EDF+C (`.edf`) → `edf_file_io.load_edf_file`
+    * BIDS `*_channels.tsv` / `*_emg.json` sidecars for grid geometry
 * **Sanitization**: ensures `data` is 2-D (samples × channels) and `time` is 1-D, swapping axes if needed.
+* **Unit**: each loader reports what the file declares; `EMGFile` normalizes it
+  via `hdsemg_shared.fileio.units.normalize_unit` and never infers one from the
+  data.
 * **Grid JSON cache**: fetched from Google Drive once per week, stored in `~/.hdsemg_cache/`.
 
 ---
@@ -248,7 +256,11 @@ for grid in emg.grids:
 # Find a specific grid
 g2x8 = emg.get_grid(grid_key="2x8")
 
-# Save a selection back to .mat
+# Work in a known unit before comparing against a physiological threshold
+if emg.unit is not None:
+    emg_uv = emg.to_unit("uV")
+
+# Save a selection back to .mat (the unit travels with it, when known)
 emg.save("selected_subset.mat")
 ```
 

--- a/docs/usage/global_parameters.md
+++ b/docs/usage/global_parameters.md
@@ -175,7 +175,9 @@ def compute_entropy(signal: np.ndarray) -> float:
 
 **Description:**
 
-* Reduces a whole HDsEMG grid to one amplitude over time, `[xV]`.
+* Reduces a whole HDsEMG grid to one amplitude over time, `[xV]` — the same
+  volt prefix as the input. `EMGFile.unit` names it; convert with
+  `emg.to_unit("uV")` before reporting an absolute number.
 * Takes the raw channel matrix plus an `emg_map`; band-pass filtering,
   MP/SD/DD differentiation and the reduction all happen inside.
 * `method='RMS'` (default) or `'ARV'`.
@@ -224,6 +226,7 @@ from hdsemg_shared.global_parameters import global_amplitude
 from hdsemg_shared.preprocessing.grid_map import emg_map_from_indices
 
 emg_file = EMGFile.load("recording.otb+")
+emg_file = emg_file.to_unit("uV")      # emg_file.unit is "mV" for OTB+/OTB4
 grid = emg_file.grids[0]
 emg_map = emg_map_from_indices(grid.emg_indices, grid.rows, grid.cols)
 
@@ -231,8 +234,8 @@ emg_map = emg_map_from_indices(grid.emg_indices, grid.rows, grid.cols)
 out = global_amplitude(emg_file.data.T, emg_map, emg_file.sampling_frequency,
                        method='RMS', derivation='SD')
 
-out.amplitude      # global amplitude over time      [xV]
-out.per_channel    # each channel's own envelope     [xV]
+out.amplitude      # global amplitude over time      [uV, matching the input]
+out.per_channel    # each channel's own envelope     [uV, matching the input]
 out.positions      # (column, row) of each channel
 out.grid_shape     # (nCols, nRows) after derivation
 out.n_channels     # how many contributed
@@ -402,6 +405,16 @@ from hdsemg_shared.global_parameters import global_amplitude
 from hdsemg_shared.preprocessing.grid_map import emg_map_from_indices
 
 emg_file = EMGFile.load(cropped_file_path)
+
+# The *_uv keys below claim microvolts, so earn the claim rather than assuming
+# it: OTB+/OTB4 hand back millivolts, and a plain .mat declares nothing at all.
+if emg_file.unit is None:
+    raise ValueError(
+        f"{cropped_file_path} declares no signal unit; refusing to write "
+        f"microvolt fields from data of unknown scale."
+    )
+emg_file = emg_file.to_unit("uV")
+
 emg_channels = emg_file.data.T          # (n_samples, n_channels) -> channels first
 
 results = {}

--- a/docs/usage/quality.md
+++ b/docs/usage/quality.md
@@ -23,6 +23,20 @@ samples-by-channels, so pass `emg.data.T` — and return one entry per row. A
 channel that is entirely NaN, an excluded or unwired position, yields NaN
 rather than raising.
 
+Amplitudes come back in whatever unit went in — that is what `[xV]` means in
+the docstrings. `EMGFile.unit` says which one that is, so convert **before**
+comparing against a threshold in µV:
+
+```python
+emg = EMGFile.load("recording.otb4")
+emg.unit                       # "mV" for OTB4, None when the file says nothing
+amp = channel_amplitude(emg.to_unit("uV").data.T, fs)   # now genuinely µV
+```
+
+`unit` is `None` for a file that declares nothing, and `to_unit` raises rather
+than guessing. Ratios and `robust_z` scores are unit-free and unaffected;
+every absolute number is not.
+
 | function | question it answers |
 |---|---|
 | `flat_channels` | is the electrode disconnected or saturated? |

--- a/tests/test_usage_examples.py
+++ b/tests/test_usage_examples.py
@@ -166,6 +166,62 @@ def test_the_pipe_recipe_over_every_grid_of_a_file():
     json.dumps({"grids": results})   # the sidecar must be JSON-serialisable
 
 
+def _millivolt_emg_file(n_channels=12, rows=4, cols=3):
+    """An EMGFile whose grid channels are the 100 uV sine, expressed in mV."""
+    from hdsemg_shared.fileio.file_io import EMGFile
+
+    data = np.vstack([_signal(n_channels) * 1e-3,          # 100 uV -> 0.1 mV
+                      np.full((1, N_SAMPLES), 30000.0)]).T  # a performed-path ref
+    desc = [f"HD10MM{rows:02d}{cols:02d} ch{i + 1}" for i in range(n_channels)]
+    desc.append("performed path")
+    emg = EMGFile(data, np.arange(N_SAMPLES) / FS, desc, FS, "f.mat", 0, "mat", "mV")
+    return emg
+
+
+def test_the_pipe_recipe_converts_before_writing_microvolt_fields(monkeypatch):
+    """
+    The prologue documented above the pipe recipe: refuse an undeclared unit,
+    otherwise convert, so the *_uv keys are microvolts rather than a guess.
+    """
+    monkeypatch.setattr("hdsemg_shared.fileio.file_io.EMGFile._grid_cache", [])
+
+    emg_file = _millivolt_emg_file()
+    assert emg_file.unit == "mV"
+
+    emg_file = emg_file.to_unit("uV")
+
+    grid = emg_file.grids[0]
+    emg_map = emg_map_from_indices(grid.emg_indices, grid.rows, grid.cols)
+    out = global_amplitude(emg_file.data.T, emg_map, FS, method="RMS", derivation="MP")
+
+    # the 1000x that the unit attribute exists to prevent
+    assert float(out.amplitude.mean()) == pytest.approx(100.0, rel=0.05)
+    # the reference channel is not EMG and keeps its own scale
+    assert emg_file.data[:, grid.ref_indices[0]].max() == pytest.approx(30000.0)
+
+
+def test_the_pipe_recipe_refuses_a_file_that_declares_no_unit(monkeypatch):
+    monkeypatch.setattr("hdsemg_shared.fileio.file_io.EMGFile._grid_cache", [])
+
+    emg_file = _millivolt_emg_file()
+    emg_file.unit = None
+
+    with pytest.raises(ValueError):
+        emg_file.to_unit("uV")
+
+
+def test_quality_page_converts_before_thresholding_in_microvolts(monkeypatch):
+    from hdsemg_shared.quality import channel_amplitude
+
+    monkeypatch.setattr("hdsemg_shared.fileio.file_io.EMGFile._grid_cache", [])
+
+    emg = _millivolt_emg_file()
+    grid_channels = emg.grids[0].emg_indices
+
+    amp = channel_amplitude(emg.to_unit("uV").data.T, FS)
+    np.testing.assert_allclose(amp.rms[grid_channels], 100.0, rtol=0.05)
+
+
 # --------------------------------------------------------------------------
 # From hdsemg-select
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to #54, which added `EMGFile.unit`. The pages that report **absolute** amplitudes still read as if the scale were known.

## Changes

**`docs/index.md`, `docs/usage/fileio.md`**
- Unit listed among the features; `.unit`, `.scale_to()` and `.to_unit()` shown in the quick example.
- `hdsemg_shared.fileio.units` added to the mkdocstrings API section, so `normalize_unit` / `conversion_factor` / `CANONICAL_UNITS` are rendered.
- The `.edf` loader added to the format-dispatch list and the intro. It had been left out when EDF support landed — unrelated to #53, but a one-line gap in the same list.

**`docs/usage/quality.md`**
- States plainly what `[xV]` in the docstrings means: the same volt prefix as the input. Shows the conversion before comparing against a µV threshold, and notes that ratios and `robust_z` are unit-free and unaffected.

**`docs/usage/global_parameters.md`**
- `out.amplitude` / `out.per_channel` annotated with the unit that actually comes out.
- The **hdsemg-pipe recipe wrote `mean_uv` / `max_uv` / `per_channel_uv` straight from OTB data**, which is millivolts — the exact 1000× error #53 exists to prevent, sitting in the docs as a copyable recipe. It now refuses a file that declares no unit and converts otherwise.

```python
if emg_file.unit is None:
    raise ValueError(...)   # rather than writing microvolt fields from an unknown scale
emg_file = emg_file.to_unit("uV")
```

## Test plan

`tests/test_usage_examples.py` exists so the documented recipes cannot rot silently. The two new prologues are covered there the same way:

- [x] `test_the_pipe_recipe_converts_before_writing_microvolt_fields` — a `"mV"` `EMGFile` carrying a 100 µV sine plus a 30000-count performed-path reference; asserts `out.amplitude.mean() ≈ 100.0` µV after conversion and that the reference channel keeps its own scale.
- [x] `test_the_pipe_recipe_refuses_a_file_that_declares_no_unit`
- [x] `test_quality_page_converts_before_thresholding_in_microvolts`
- [x] Full suite: 258 passed, 13 skipped.
- [x] `mkdocs build` clean; the `units` module renders on the fileio page.

Docs and tests only — no source changes.